### PR TITLE
feat: add wordpress publishing form

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,41 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 type ConvertResponse = {
   markdown: string
   html: string
   engine: string
   stats: Record<string, any>
+}
+
+type WordpressResponse = {
+  success?: boolean
+  message?: string
+  error?: string
+  link?: string
+  url?: string
+  permalink?: string
+  postId?: number
+}
+
+function extractTitle(markdown: string) {
+  const lines = markdown.split(/\r?\n/)
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    if (trimmed.startsWith('#')) return trimmed.replace(/^#+\s*/, '').trim()
+    return trimmed
+  }
+  return ''
+}
+
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
 }
 
 export default function App() {
@@ -14,6 +45,20 @@ export default function App() {
   const [busy, setBusy] = useState(false)
   const [tab, setTab] = useState<'md'|'html'>('md')
   const [error, setError] = useState('')
+  const [wpUrl, setWpUrl] = useState('')
+  const [wpUsername, setWpUsername] = useState('')
+  const [wpPassword, setWpPassword] = useState('')
+  const [wpTesting, setWpTesting] = useState(false)
+  const [wpConnected, setWpConnected] = useState(false)
+  const [wpMessage, setWpMessage] = useState('')
+  const [wpError, setWpError] = useState('')
+  const [postTitle, setPostTitle] = useState('')
+  const [postSlug, setPostSlug] = useState('')
+  const [postStatus, setPostStatus] = useState<'draft' | 'publish'>('draft')
+  const [publishBusy, setPublishBusy] = useState(false)
+  const [publishMessage, setPublishMessage] = useState('')
+  const [publishError, setPublishError] = useState('')
+  const [slugTouched, setSlugTouched] = useState(false)
 
   const backend = import.meta.env.VITE_API_URL || 'http://localhost:8000'
 
@@ -26,6 +71,12 @@ export default function App() {
       if (!res.ok) throw new Error(await res.text())
       const data = await res.json() as ConvertResponse
       setMd(data.markdown); setHtml(data.html); setEngine(data.engine); setTab('md')
+      const detectedTitle = extractTitle(data.markdown)
+      setPostTitle(detectedTitle)
+      setPublishMessage('')
+      setPublishError('')
+      setSlugTouched(false)
+      setPostSlug(detectedTitle ? slugify(detectedTitle) : '')
     } catch (e: any) {
       setError(e?.message || 'Erreur de conversion')
     } finally { setBusy(false) }
@@ -46,6 +97,129 @@ export default function App() {
     const a = document.createElement('a')
     a.href = URL.createObjectURL(blob); a.download = 'article.md'; a.click()
     URL.revokeObjectURL(a.href)
+  }
+
+  useEffect(() => {
+    if (!slugTouched) {
+      setPostSlug(postTitle ? slugify(postTitle) : '')
+    }
+  }, [postTitle, slugTouched])
+
+  useEffect(() => {
+    setWpConnected(false)
+    setWpMessage('')
+    setWpError('')
+  }, [wpUrl, wpUsername, wpPassword])
+
+  async function testWordpressConnection() {
+    if (!wpUrl || !wpUsername || !wpPassword) {
+      setWpError('Veuillez renseigner l\'URL, l\'identifiant et le mot de passe.')
+      setWpMessage('')
+      return
+    }
+
+    setWpTesting(true)
+    setWpConnected(false)
+    setWpMessage('')
+    setWpError('')
+
+    try {
+      const payload = {
+        siteUrl: wpUrl,
+        url: wpUrl,
+        baseUrl: wpUrl,
+        username: wpUsername,
+        user: wpUsername,
+        applicationPassword: wpPassword,
+        password: wpPassword,
+      }
+
+      const res = await fetch(`${backend}/wordpress/connect`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+
+      let data: WordpressResponse | null = null
+      try {
+        data = await res.json()
+      } catch {}
+
+      if (!res.ok || data?.success === false) {
+        throw new Error(data?.message || data?.error || 'Connexion échouée')
+      }
+
+      setWpConnected(true)
+      setWpMessage(data?.message || 'Connexion à WordPress réussie.')
+    } catch (e: any) {
+      setWpError(e?.message || 'Impossible de se connecter à WordPress.')
+    } finally {
+      setWpTesting(false)
+    }
+  }
+
+  async function publishToWordpress() {
+    if (!md && !html) {
+      setPublishError('Convertissez un document avant de publier sur WordPress.')
+      setPublishMessage('')
+      return
+    }
+
+    if (!wpUrl || !wpUsername || !wpPassword) {
+      setPublishError('Veuillez renseigner les informations de connexion WordPress.')
+      setPublishMessage('')
+      return
+    }
+
+    setPublishBusy(true)
+    setPublishMessage('')
+    setPublishError('')
+
+    try {
+      const payload: Record<string, unknown> = {
+        siteUrl: wpUrl,
+        url: wpUrl,
+        baseUrl: wpUrl,
+        username: wpUsername,
+        user: wpUsername,
+        applicationPassword: wpPassword,
+        password: wpPassword,
+        title: postTitle,
+        status: postStatus,
+        markdown: md,
+        html,
+        content: html,
+      }
+
+      if (postSlug) payload.slug = postSlug
+
+      const res = await fetch(`${backend}/wordpress/publish`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+
+      let data: WordpressResponse | null = null
+      try {
+        data = await res.json()
+      } catch {}
+
+      if (!res.ok || data?.success === false) {
+        throw new Error(data?.message || data?.error || 'Publication échouée')
+      }
+
+      const link = data?.link || data?.url || data?.permalink
+      if (link) {
+        setPublishMessage(`Article publié : ${link}`)
+      } else {
+        const message = data?.message || 'Article publié avec succès sur WordPress.'
+        setPublishMessage(message)
+      }
+    } catch (e: any) {
+      setPublishError(e?.message || 'Impossible de publier sur WordPress.')
+    } finally {
+      setPublishBusy(false)
+    }
   }
 
   return (
@@ -77,6 +251,102 @@ export default function App() {
             <div style={{border:'1px solid #e5e7eb', borderRadius:12, padding:12, minHeight:300}}
                  dangerouslySetInnerHTML={{__html: html}} />
           )}
+        </div>
+
+        <div className="card" style={{marginTop: 24}}>
+          <h2 className="section-title">Connexion &amp; publication WordPress</h2>
+          <p style={{marginTop:0}}>Renseignez votre site WordPress puis publiez directement le contenu converti.</p>
+
+          <div className="form-grid">
+            <label className="field">
+              <span>URL du site</span>
+              <input
+                type="url"
+                placeholder="https://monsite.com"
+                value={wpUrl}
+                onChange={(e) => setWpUrl(e.target.value)}
+                autoComplete="url"
+              />
+            </label>
+            <label className="field">
+              <span>Identifiant</span>
+              <input
+                type="text"
+                placeholder="admin"
+                value={wpUsername}
+                onChange={(e) => setWpUsername(e.target.value)}
+                autoComplete="username"
+              />
+            </label>
+            <label className="field">
+              <span>Mot de passe / Application password</span>
+              <input
+                type="password"
+                placeholder="Mot de passe application"
+                value={wpPassword}
+                onChange={(e) => setWpPassword(e.target.value)}
+                autoComplete="current-password"
+              />
+            </label>
+          </div>
+
+          <div className="actions-row">
+            <button
+              className="button outline"
+              onClick={testWordpressConnection}
+              disabled={wpTesting}
+            >
+              {wpTesting ? 'Connexion…' : 'Tester la connexion'}
+            </button>
+            {wpConnected && !wpTesting && <span className="status success">Connecté</span>}
+          </div>
+          {wpMessage && <p className="status success">{wpMessage}</p>}
+          {wpError && <p className="status error">{wpError}</p>}
+
+          <hr className="divider" />
+
+          <div className="form-grid">
+            <label className="field">
+              <span>Titre de l&apos;article</span>
+              <input
+                type="text"
+                placeholder="Titre de l'article"
+                value={postTitle}
+                onChange={(e) => setPostTitle(e.target.value)}
+              />
+            </label>
+            <label className="field">
+              <span>Slug (optionnel)</span>
+              <input
+                type="text"
+                placeholder="titre-de-l-article"
+                value={postSlug}
+                onChange={(e) => {
+                  setPostSlug(e.target.value)
+                  setSlugTouched(true)
+                }}
+              />
+            </label>
+            <label className="field">
+              <span>Statut WordPress</span>
+              <select value={postStatus} onChange={(e) => setPostStatus(e.target.value as 'draft' | 'publish')}>
+                <option value="draft">Brouillon</option>
+                <option value="publish">Publié</option>
+              </select>
+            </label>
+          </div>
+
+          <button
+            className="button"
+            onClick={publishToWordpress}
+            disabled={publishBusy}
+            style={{marginTop: 16}}
+          >
+            {publishBusy ? 'Publication…' : 'Publier sur WordPress'}
+          </button>
+
+          {publishMessage && <p className="status success" style={{marginTop:12}}>{publishMessage}</p>}
+          {publishError && <p className="status error" style={{marginTop:12}}>{publishError}</p>}
         </div>
       </main>
     </>

--- a/src/styles.css
+++ b/src/styles.css
@@ -7,8 +7,20 @@ body{margin:0;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,
 .card{background:#fff;border:1px solid #e5e7eb;border-radius:16px;padding:20px;box-shadow:0 6px 24px rgba(0,0,0,.05)}
 .button{background:var(--lava-red);color:#fff;border:none;padding:10px 14px;border-radius:12px;font-weight:600;cursor:pointer}
 .button[disabled]{opacity:.6;cursor:not-allowed}
+.button.outline{background:transparent;color:var(--lava-red);border:1px solid var(--lava-red)}
 .tabs{display:flex;gap:8px;margin-top:16px}
 .tab{padding:8px 12px;border:1px solid #e5e7eb;border-radius:10px;cursor:pointer;background:#fff}
 .tab.active{border-color:var(--lava-red);color:var(--lava-red)}
 textarea{width:100%;min-height:300px;padding:12px;border:1px solid #e5e7eb;border-radius:12px}
 .footer{color:#6b7280;font-size:12px;margin-top:24px;text-align:center}
+.section-title{margin:0 0 12px;font-size:20px}
+.form-grid{display:grid;gap:12px;margin-top:16px}
+@media(min-width:720px){.form-grid{grid-template-columns:repeat(3,minmax(0,1fr))}}
+.field{display:flex;flex-direction:column;gap:6px;font-size:14px}
+.field span{font-weight:600}
+input,select{padding:10px 12px;border:1px solid #e5e7eb;border-radius:10px;font-size:15px}
+.actions-row{display:flex;align-items:center;gap:12px;margin-top:16px}
+.status{font-size:14px}
+.status.success{color:#047857}
+.status.error{color:#b91c1c}
+.divider{margin:20px 0;border:none;border-top:1px solid #e5e7eb}


### PR DESCRIPTION
## Summary
- add a WordPress connection and publishing workflow to trigger the new backend APIs
- auto-detect the article title from converted markdown and allow overriding slug/status
- extend styling to accommodate the new form controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd3074480c832797139953d4a10eed