### PR TITLE
Align frontend WordPress workflows with backend

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -14,8 +14,9 @@ body{margin:0;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,
 textarea{width:100%;min-height:300px;padding:12px;border:1px solid #e5e7eb;border-radius:12px}
 .footer{color:#6b7280;font-size:12px;margin-top:24px;text-align:center}
 .section-title{margin:0 0 12px;font-size:20px}
-.form-grid{display:grid;gap:12px;margin-top:16px}
-@media(min-width:720px){.form-grid{grid-template-columns:repeat(3,minmax(0,1fr))}}
+.form-grid{display:grid;gap:12px;margin-top:16px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+.subscriptions-preview{border:1px solid #e5e7eb;border-radius:12px;padding:12px;background:#f9fafb;max-height:320px;overflow:auto}
+.subscriptions-preview summary{cursor:pointer;font-weight:600;margin-bottom:8px}
 .field{display:flex;flex-direction:column;gap:6px;font-size:14px}
 .field span{font-weight:600}
 input,select{padding:10px 12px;border:1px solid #e5e7eb;border-radius:10px;font-size:15px}


### PR DESCRIPTION
## Summary
- split the WordPress credential form between application and admin passwords so payloads match the backend expectations
- add support for fetching the WooCommerce subscriptions page HTML and link via the new backend endpoint
- tweak styling to accommodate the extra fields and show a preview panel for the subscriptions HTML

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd9b2da5f48327a4e58393983a3a80