### PR TITLE
Ensure admin-only credentials for WooCommerce exports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,9 @@ type WordpressResponse = {
   url?: string
   permalink?: string
   postId?: number
+  status?: string
+  username?: string
+  displayName?: string
 }
 
 type WordpressExportResponse = {
@@ -105,14 +108,13 @@ export default function App() {
   }
 
   function buildWordpressAdminPayload() {
-    const password = wpAdminPassword || wpAppPassword
     return {
       siteUrl: normalisedWpUrl,
       url: normalisedWpUrl,
       baseUrl: normalisedWpUrl,
       username: wpUsername,
       user: wpUsername,
-      password: password || undefined,
+      password: wpAdminPassword || undefined,
     }
   }
 
@@ -286,8 +288,8 @@ export default function App() {
   }
 
   async function exportSubscriptions() {
-    if (!wpUrl || !wpUsername || (!wpAdminPassword && !wpAppPassword)) {
-      setExportError('Veuillez renseigner l\'URL, l\'identifiant et votre mot de passe WordPress.')
+    if (!wpUrl || !wpUsername || !wpAdminPassword) {
+      setExportError('Veuillez renseigner l\'URL, l\'identifiant et votre mot de passe WordPress (non application password).')
       setExportMessage('')
       return
     }
@@ -325,8 +327,8 @@ export default function App() {
   }
 
   async function fetchSubscriptionsPreview() {
-    if (!wpUrl || !wpUsername || (!wpAdminPassword && !wpAppPassword)) {
-      setSubscriptionsError('Veuillez renseigner l\'URL, l\'identifiant et votre mot de passe WordPress.')
+    if (!wpUrl || !wpUsername || !wpAdminPassword) {
+      setSubscriptionsError('Veuillez renseigner l\'URL, l\'identifiant et votre mot de passe WordPress (non application password).')
       setSubscriptionsMessage('')
       setSubscriptionsHtml('')
       setSubscriptionsUrl('')
@@ -346,7 +348,7 @@ export default function App() {
         body: JSON.stringify({
           base_url: normalisedWpUrl,
           username: wpUsername,
-          password: wpAdminPassword || wpAppPassword,
+          password: wpAdminPassword,
         }),
       })
 


### PR DESCRIPTION
## Summary
- require the admin password for WooCommerce export and preview actions
- stop sending an application password to admin endpoints
- update the WordPress response type hints to include optional metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dda1dff26c83278be7738f46cbf5df