### PR TITLE
Fix React refresh runtime compatibility

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,27 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type PluginOption } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
+
+const reactRefreshCompatibility = (): PluginOption => ({
+  name: 'react-refresh-compatibility',
+  apply: 'serve',
+  enforce: 'post',
+  transform(code, id) {
+    if (!id.includes('/@react-refresh')) return null
+
+    if (!code.includes('exports.injectIntoGlobalHook')) return null
+
+    return {
+      code: `${code}\nexport const injectIntoGlobalHook = exports.injectIntoGlobalHook;\n`,
+      map: null
+    }
+  }
+})
 
 export default defineConfig({
   plugins: [
     react(),
+    reactRefreshCompatibility(),
     VitePWA({
       registerType: 'autoUpdate',
       workbox: { cleanupOutdatedCaches: true },


### PR DESCRIPTION
## Summary
- add a Vite development plugin that exposes `injectIntoGlobalHook` as a named export on the virtual `/@react-refresh` module to match expectations from cached clients
- keep existing React refresh behaviour while avoiding runtime syntax errors that prevented the app from rendering

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0e074fd6c8327bafd335982e921d4