### PR TITLE
Fix react refresh compatibility for Vite runtime

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,12 +7,12 @@ const reactRefreshCompatibility = (): PluginOption => ({
   apply: 'serve',
   enforce: 'post',
   transform(code, id) {
-    if (!id.includes('/@react-refresh')) return null
+    if (!id.includes('@react-refresh')) return null
 
-    if (!code.includes('exports.injectIntoGlobalHook')) return null
+    if (!code.includes('injectIntoGlobalHook')) return null
 
     return {
-      code: `${code}\nexport const injectIntoGlobalHook = exports.injectIntoGlobalHook;\n`,
+      code: `${code}\nexport const injectIntoGlobalHook = exports.injectIntoGlobalHook ?? exports.default?.injectIntoGlobalHook;\n`,
       map: null
     }
   }


### PR DESCRIPTION
## Summary
- relax the react-refresh compatibility plugin check so it runs against updated Vite ids
- export the injectIntoGlobalHook symbol even when it hangs off the default export

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0e3876000832798d1c2558ecf5861