### PR TITLE
Prefer Chrome before Firefox for Woo export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -419,7 +419,8 @@ export default function App() {
           baseUrl: normalisedWpUrl,
           username: wpUsername,
           password: wpAdminPassword,
-          browser: 'firefox', // backend Fly: Firefox/Gecko
+          browser: 'chrome',
+          fallbackBrowsers: ['firefox'],
           headless: true
         }))
       }


### PR DESCRIPTION
## Summary
- request the backend to use Chrome for WooCommerce subscription exports with Firefox as a fallback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0e846059c8327b075ef6205694540