### PR TITLE
Add CSV-driven kanban dashboards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import KanbanBoard from './components/KanbanBoard'
 
 /* =========================
    Types de réponses backend
@@ -642,7 +643,46 @@ export default function App() {
           {wpMessage && <p className="status success">{wpMessage}</p>}
           {wpError && <p className="status error">{wpError}</p>}
 
-         
+          <hr className="divider" />
+
+          <h3 className="section-subtitle">Publication WordPress</h3>
+          <p style={{marginTop:0}}>Ajustez le titre, le slug et publiez directement le contenu converti.</p>
+
+          <div className="form-grid">
+            <label className="field">
+              <span>Titre de l’article</span>
+              <input
+                type="text"
+                value={postTitle}
+                onChange={(e) => setPostTitle(e.target.value)}
+                placeholder="Titre de l’article"
+              />
+            </label>
+            <label className="field">
+              <span>Slug</span>
+              <input
+                type="text"
+                value={postSlug}
+                onChange={(e) => { setPostSlug(e.target.value); setSlugTouched(true) }}
+                placeholder="slug-de-l-article"
+              />
+            </label>
+            <label className="field">
+              <span>Statut</span>
+              <select value={postStatus} onChange={(e) => setPostStatus(e.target.value as 'draft' | 'publish')}>
+                <option value="draft">Brouillon</option>
+                <option value="publish">Publier</option>
+              </select>
+            </label>
+          </div>
+
+          <div className="actions-row" style={{marginTop:16}}>
+            <button className="button" onClick={publishToWordpress} disabled={publishBusy}>
+              {publishBusy ? 'Publication…' : 'Publier sur WordPress'}
+            </button>
+          </div>
+          {publishMessage && <p className="status success" style={{marginTop:12}}>{publishMessage}</p>}
+          {publishError && <p className="status error" style={{marginTop:12}}>{publishError}</p>}
 
           <hr className="divider" />
 
@@ -706,6 +746,20 @@ export default function App() {
               <div dangerouslySetInnerHTML={{ __html: subscriptionsHtml }} />
             </details>
           )}
+        </div>
+
+        <div className="card" style={{marginTop: 24}}>
+          <KanbanBoard
+            title="Kanban vitrine"
+            csvUrl="/csv/kanban_vitrine_M1_shortlist.csv"
+          />
+        </div>
+
+        <div className="card" style={{marginTop: 24}}>
+          <KanbanBoard
+            title="Kanban Lava Tickets"
+            csvUrl="/csv/kanban_lava_tickets_wp_mapping_with_difficulty.csv"
+          />
         </div>
       </main>
     </>

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -1,0 +1,340 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+
+type KanbanColumnId = 'facile' | 'moyen' | 'difficile' | 'non-classe'
+
+type KanbanRow = {
+  ID?: string
+  Titre?: string
+  Labels?: string
+  Description?: string
+  ExplicationNonTech?: string
+  CriteresAcceptation?: string
+  Dependances?: string
+  WPFeature?: string
+  PluginsExtensionsWP?: string
+  Difficulte?: string
+  Couche?: string
+}
+
+type KanbanItem = {
+  id: string
+  title: string
+  labels: string[]
+  description: string
+  explanation: string
+  acceptance: string
+  dependencies: string
+  feature: string
+  plugins: string
+  difficulty: string
+  layer: string
+  status: KanbanColumnId
+}
+
+type KanbanBoardProps = {
+  csvUrl: string
+  title: string
+}
+
+type CsvRow = string[]
+
+function parseCsv(text: string): CsvRow[] {
+  const rows: CsvRow[] = []
+  let current: string[] = []
+  let value = ''
+  let inQuotes = false
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]
+
+    if (inQuotes) {
+      if (char === '"') {
+        const next = text[i + 1]
+        if (next === '"') {
+          value += '"'
+          i++
+        } else {
+          inQuotes = false
+        }
+      } else {
+        value += char
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true
+      } else if (char === ',') {
+        current.push(value)
+        value = ''
+      } else if (char === '\r') {
+        continue
+      } else if (char === '\n') {
+        current.push(value)
+        rows.push(current)
+        current = []
+        value = ''
+      } else {
+        value += char
+      }
+    }
+  }
+
+  current.push(value)
+  rows.push(current)
+
+  return rows.filter(row => row.length > 1 || (row[0] && row[0].trim() !== ''))
+}
+
+function parseCsvWithHeader(text: string): KanbanRow[] {
+  const rows = parseCsv(text)
+  if (!rows.length) return []
+  const headers = rows[0].map(header => header.trim())
+  const items: KanbanRow[] = []
+
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i]
+    const record: KanbanRow = {}
+    headers.forEach((header, index) => {
+      const value = row[index] ?? ''
+      ;(record as Record<string, string>)[header] = value.trim()
+    })
+    items.push(record)
+  }
+  return items
+}
+
+const columns: { id: KanbanColumnId; title: string; accent: string }[] = [
+  { id: 'facile', title: 'Facile', accent: '#22c55e' },
+  { id: 'moyen', title: 'Moyen', accent: '#eab308' },
+  { id: 'difficile', title: 'Difficile', accent: '#f97316' },
+  { id: 'non-classe', title: 'À trier', accent: '#94a3b8' },
+]
+
+function normaliseDifficulty(value: string | undefined): KanbanColumnId {
+  if (!value) return 'non-classe'
+  const lower = value.trim().toLowerCase()
+  if (lower.startsWith('fac')) return 'facile'
+  if (lower.startsWith('moy')) return 'moyen'
+  if (lower.startsWith('dif')) return 'difficile'
+  return 'non-classe'
+}
+
+function parseLabels(raw?: string): string[] {
+  if (!raw) return []
+  return raw
+    .split(',')
+    .map(label => label.replace(/\[|\]|"|'/g, '').trim())
+    .filter(Boolean)
+}
+
+function parseDependencies(raw?: string): string[] {
+  if (!raw) return []
+  return raw
+    .split(',')
+    .map(dep => dep.trim())
+    .filter(Boolean)
+}
+
+function buildItem(row: KanbanRow): KanbanItem | null {
+  const id = row.ID?.trim()
+  const title = row.Titre?.trim()
+  if (!id || !title) return null
+  const status = normaliseDifficulty(row.Difficulte)
+
+  return {
+    id,
+    title,
+    labels: parseLabels(row.Labels),
+    description: row.Description?.trim() || '',
+    explanation: row.ExplicationNonTech?.trim() || '',
+    acceptance: row.CriteresAcceptation?.trim() || '',
+    dependencies: parseDependencies(row.Dependances).join(', '),
+    feature: row.WPFeature?.trim() || '',
+    plugins: row.PluginsExtensionsWP?.trim() || '',
+    difficulty: row.Difficulte?.trim() || '',
+    layer: row.Couche?.trim() || '',
+    status,
+  }
+}
+
+export default function KanbanBoard({ csvUrl, title }: KanbanBoardProps) {
+  const [items, setItems] = useState<KanbanItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [draggingId, setDraggingId] = useState<string | null>(null)
+  const [activeColumn, setActiveColumn] = useState<KanbanColumnId | null>(null)
+  const initialItemsRef = useRef<KanbanItem[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      setLoading(true)
+      setError('')
+      try {
+        const res = await fetch(csvUrl)
+        if (!res.ok) throw new Error(`Impossible de charger le CSV (${res.status})`)
+        const text = await res.text()
+        if (cancelled) return
+        const parsed = parseCsvWithHeader(text)
+        const mapped = parsed
+          .map(buildItem)
+          .filter((item): item is KanbanItem => Boolean(item))
+
+        initialItemsRef.current = mapped.map(item => ({ ...item }))
+        setItems(mapped)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Erreur inconnue lors du chargement du CSV.'
+        setError(message)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [csvUrl])
+
+  const grouped = useMemo(() => {
+    return columns.map(column => ({
+      ...column,
+      items: items.filter(item => item.status === column.id),
+    }))
+  }, [items])
+
+  function handleDrop(ev: React.DragEvent<HTMLDivElement>, columnId: KanbanColumnId) {
+    ev.preventDefault()
+    const droppedId = ev.dataTransfer.getData('text/plain')
+    if (!droppedId) return
+    setItems(prev =>
+      prev.map(item =>
+        item.id === droppedId
+          ? {
+              ...item,
+              status: columnId,
+            }
+          : item,
+      ),
+    )
+    setActiveColumn(null)
+  }
+
+  function handleDragOver(ev: React.DragEvent<HTMLDivElement>, columnId: KanbanColumnId) {
+    ev.preventDefault()
+    if (activeColumn !== columnId) setActiveColumn(columnId)
+  }
+
+  function handleDragLeave() {
+    setActiveColumn(null)
+  }
+
+  function handleDragStart(ev: React.DragEvent<HTMLElement>, itemId: string) {
+    ev.dataTransfer.setData('text/plain', itemId)
+    ev.dataTransfer.effectAllowed = 'move'
+    setDraggingId(itemId)
+  }
+
+  function handleDragEnd() {
+    setDraggingId(null)
+    setActiveColumn(null)
+  }
+
+  function resetBoard() {
+    setItems(initialItemsRef.current.map(item => ({ ...item })))
+  }
+
+  return (
+    <div className="kanban-board">
+      <div className="kanban-board__header">
+        <div>
+          <h3 className="kanban-board__title">{title}</h3>
+          {loading && <p className="kanban-board__status">Chargement…</p>}
+          {error && <p className="kanban-board__status error">{error}</p>}
+        </div>
+        <button className="button outline" onClick={resetBoard} disabled={loading}>
+          Réinitialiser
+        </button>
+      </div>
+
+      <div className="kanban-columns">
+        {grouped.map(column => (
+          <div
+            key={column.id}
+            className={`kanban-column${activeColumn === column.id ? ' drag-over' : ''}`}
+            onDragOver={ev => handleDragOver(ev, column.id)}
+            onDrop={ev => handleDrop(ev, column.id)}
+            onDragLeave={handleDragLeave}
+            aria-label={`Colonne ${column.title}`}
+          >
+            <header className="kanban-column__header" style={{ borderBottomColor: column.accent }}>
+              <span>{column.title}</span>
+              <span className="kanban-column__count">{column.items.length}</span>
+            </header>
+            <div className="kanban-column__body">
+              {column.items.map(item => (
+                <article
+                  key={item.id}
+                  className={`kanban-card${draggingId === item.id ? ' dragging' : ''}`}
+                  draggable
+                  onDragStart={ev => handleDragStart(ev, item.id)}
+                  onDragEnd={handleDragEnd}
+                >
+                  <div className="kanban-card__id">{item.id}</div>
+                  <h4 className="kanban-card__title">{item.title}</h4>
+                  <div className="kanban-card__meta">
+                    {item.difficulty && <span className="kanban-tag">{item.difficulty}</span>}
+                    {item.layer && <span className="kanban-tag">{item.layer}</span>}
+                  </div>
+                  {item.labels.length > 0 && (
+                    <div className="kanban-card__labels">
+                      {item.labels.map(label => (
+                        <span key={label} className="kanban-label">
+                          {label}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  {item.description && <p className="kanban-card__text">{item.description}</p>}
+                  {item.explanation && (
+                    <details className="kanban-card__details">
+                      <summary>Explication</summary>
+                      <p>{item.explanation}</p>
+                    </details>
+                  )}
+                  {item.acceptance && (
+                    <details className="kanban-card__details">
+                      <summary>Critères d’acceptation</summary>
+                      <p>{item.acceptance}</p>
+                    </details>
+                  )}
+                  {(item.dependencies || item.feature || item.plugins) && (
+                    <div className="kanban-card__extra">
+                      {item.dependencies && (
+                        <p>
+                          <strong>Dépendances :</strong> {item.dependencies}
+                        </p>
+                      )}
+                      {item.feature && (
+                        <p>
+                          <strong>WP Feature :</strong> {item.feature}
+                        </p>
+                      )}
+                      {item.plugins && (
+                        <p>
+                          <strong>Plugins :</strong> {item.plugins}
+                        </p>
+                      )}
+                    </div>
+                  )}
+                </article>
+              ))}
+              {column.items.length === 0 && !loading && (
+                <p className="kanban-column__empty">Aucune carte</p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -25,3 +25,29 @@ input,select{padding:10px 12px;border:1px solid #e5e7eb;border-radius:10px;font-
 .status.success{color:#047857}
 .status.error{color:#b91c1c}
 .divider{margin:20px 0;border:none;border-top:1px solid #e5e7eb}
+.kanban-board{display:flex;flex-direction:column;gap:16px}
+.kanban-board__header{display:flex;flex-wrap:wrap;align-items:flex-start;justify-content:space-between;gap:12px}
+.kanban-board__title{margin:0;font-size:18px}
+.kanban-board__status{margin:4px 0 0;font-size:14px;color:#475569}
+.kanban-board__status.error{color:#b91c1c}
+.kanban-columns{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(240px,1fr))}
+.kanban-column{background:#f8fafc;border:1px solid #e2e8f0;border-radius:16px;display:flex;flex-direction:column;min-height:280px;transition:border-color .2s,box-shadow .2s}
+.kanban-column.drag-over{border-color:#6366f1;box-shadow:0 0 0 3px rgba(99,102,241,.2)}
+.kanban-column__header{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;border-bottom:3px solid rgba(148,163,184,.4);font-weight:600}
+.kanban-column__count{background:#e2e8f0;border-radius:999px;padding:2px 8px;font-size:12px}
+.kanban-column__body{flex:1;padding:12px;display:flex;flex-direction:column;gap:12px}
+.kanban-column__empty{margin:0;padding:12px;text-align:center;color:#94a3b8;font-size:14px;border:1px dashed #cbd5f5;border-radius:12px;background:#fff}
+.kanban-card{background:#fff;border-radius:14px;border:1px solid #e2e8f0;padding:12px;box-shadow:0 6px 18px rgba(15,23,42,.08);cursor:grab;display:flex;flex-direction:column;gap:8px}
+.kanban-card.dragging{opacity:.5}
+.kanban-card__id{font-size:12px;text-transform:uppercase;color:#64748b;letter-spacing:.03em;font-weight:600}
+.kanban-card__title{margin:0;font-size:16px;font-weight:700;color:#0f172a}
+.kanban-card__meta{display:flex;flex-wrap:wrap;gap:6px}
+.kanban-tag{background:#eff6ff;color:#1d4ed8;padding:2px 8px;border-radius:999px;font-size:12px;font-weight:600}
+.kanban-card__labels{display:flex;flex-wrap:wrap;gap:6px}
+.kanban-label{background:#1e293b;color:#f8fafc;padding:2px 8px;border-radius:8px;font-size:12px;font-weight:500}
+.kanban-card__text{margin:0;font-size:14px;line-height:1.4;color:#1f2937}
+.kanban-card__details summary{cursor:pointer;font-size:13px;font-weight:600;color:#1d4ed8}
+.kanban-card__details p{margin:6px 0 0;font-size:13px;line-height:1.5;color:#334155}
+.kanban-card__extra{font-size:13px;display:flex;flex-direction:column;gap:4px;color:#334155}
+.kanban-card__extra strong{color:#0f172a;font-weight:600}
+@media (max-width:768px){.kanban-columns{grid-template-columns:repeat(auto-fit,minmax(200px,1fr))}}


### PR DESCRIPTION
## Summary
- add a reusable CSV-backed kanban board component with drag-and-drop and reset controls
- style the kanban UI and embed vitrine and Lava tickets boards fed from the public CSV files
- expose the existing WordPress publication form controls so the publish workflow is usable from the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e524c4f348832284b71de76f591b10