### PR TITLE
docs: clarify Fly.io deployment steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,50 @@
-# React + TypeScript + Vite
+# Lava Web Client
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This project is a Vite + React front-end for the Lava tools platform. The repository contains everything required to build a static bundle that is served through Nginx in production.
 
-Currently, two official plugins are available:
+## Local development
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm install
+npm run dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+The dev server defaults to `http://localhost:5173`.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+## Building locally
 
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+To create a production bundle, run:
+
+```bash
+npm run build
 ```
-# Lava
+
+The output is written to the `dist/` directory.
+
+## Deploying to Fly.io
+
+The app ships with a `fly.toml` configuration and a Dockerfile that builds the static bundle and serves it with Nginx. Fly.io can build the image directly from this repository—you do **not** need to reference a pre-built image.
+
+1. Log in to Fly:
+
+   ```bash
+   fly auth login
+   ```
+
+2. Deploy using the existing configuration:
+
+   ```bash
+   fly deploy --config fly.toml
+   ```
+
+   This command asks Fly's builder to create the image from `Dockerfile` and deploy it. Passing `--image <tag>` will only work if that tag already exists in the Fly registry; otherwise Fly returns `Could not find image ...`. Running `fly deploy` without `--image` avoids that failure.
+
+3. If you need to override the API URL exposed to the front-end, edit the `VITE_API_URL` entry under `[build.args]` in `fly.toml` before deploying.
+
+## Environment variables
+
+The build expects a `VITE_API_URL` value so the front-end can reach the backend API. The Fly configuration sets this argument automatically for production deploys.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- replace the template README with project specific documentation
- add clear Fly.io deployment steps that rely on the repository Dockerfile instead of a missing pre-built image
- explain how to adjust the VITE_API_URL build argument before deploying

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e534c80b34832298c1740bf4e4eb95